### PR TITLE
GCI: Store Generated PDF With Infinispan

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     // https://mvnrepository.com/artifact/org.freemarker/freemarker
     compile group: 'org.freemarker', name: 'freemarker', version: '2.3.20'
 
+    // https://mvnrepository.com/artifact/org.infinispan/infinispan-embedded
+    compile group: 'org.infinispan', name: 'infinispan-embedded', version: '9.1.4.Final'
 
     compile 'com.sun.mail:javax.mail:1.6.0'
 

--- a/src/main/java/org/jbossoutreach/certifier/Constants.java
+++ b/src/main/java/org/jbossoutreach/certifier/Constants.java
@@ -3,5 +3,7 @@ package org.jbossoutreach.certifier;
 
 public class Constants {
     public static final String KEY = "key";
+    public static final String SERVER_URL = "http://localhost:4000";
+    public static final String CERTIFICATE_PATH = "/fetchCert/";
 
 }

--- a/src/main/java/org/jbossoutreach/certifier/route/GenerateCertRoute.java
+++ b/src/main/java/org/jbossoutreach/certifier/route/GenerateCertRoute.java
@@ -3,22 +3,33 @@ package org.jbossoutreach.certifier.route;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.DefaultCacheManager;
+
+import org.jbossoutreach.certifier.Constants;
 import org.jbossoutreach.certifier.model.Certificate;
 import org.jbossoutreach.certifier.model.Student;
 import org.jbossoutreach.certifier.service.CertManager;
 
 public class GenerateCertRoute implements Route {
     private final CertManager certManager;
+    private DefaultCacheManager cacheManager;
+    private Cache<String, String> cache;
 
     public GenerateCertRoute(CertManager certManager) {
         this.certManager = certManager;
+
+        cacheManager = new DefaultCacheManager();
+        cacheManager.defineConfiguration("certificateCache", new ConfigurationBuilder().build());
+        cache = cacheManager.getCache("certificateCache");
     }
 
     @Override
     public void setup(Router router) {
-
         router.route().handler(BodyHandler.create());
         router.post("/generateCert").handler(this::generateCert);
+        router.get("/fetchCert/*").handler(this::fetchCert);
     }
 
     private void generateCert(RoutingContext routingContext) {
@@ -41,10 +52,28 @@ public class GenerateCertRoute implements Route {
                     .setStatusCode(500)
                     .end("Failed to generate the certificate.");
         } else {
+
+            //Save the generated project in infinispan cache and return the url to fetch it.
+            //Example URL: http://localhost:4000/fetchCert/johndoe@example.com.pdf
+            final String fileURL = Constants.CERTIFICATE_PATH + student.getEmail() + ".pdf";
+            this.cache.put(fileURL, outPath);
+
             routingContext.response()
                     .setStatusCode(201)
-                    .sendFile(outPath);
+                    .end(Constants.SERVER_URL + fileURL);
         }
     }
 
+    private void fetchCert(RoutingContext routingContext) {
+        String certFile = cache.get(routingContext.request().path());
+        if (certFile == null) {
+            routingContext.response()
+                    .setStatusCode(500)
+                    .end("Failed to fetch the certificate.");
+        } else {
+            routingContext.response()
+                    .setStatusCode(201)
+                    .sendFile(certFile);
+        }
+    }
 }


### PR DESCRIPTION
For the [task](https://codein.withgoogle.com/tasks/6578827595612160).
Upon the query for generating the PDF, the file will be stored in Infinispan cache.
A URL that can be used to fetch the PDF will be returned in the response.

SCREENSHOTS
Generate the PDF & return the URL
<img width="887" alt="screen shot 2018-01-09 at 15 33 31" src="https://user-images.githubusercontent.com/16971971/34709588-c8e31a30-f552-11e7-94b5-4527087575fa.png">

Fetch the PDF
<img width="1371" alt="screen shot 2018-01-09 at 15 33 40" src="https://user-images.githubusercontent.com/16971971/34709584-c5cd07a2-f552-11e7-9c7f-e8d3a378d2c4.png">

  